### PR TITLE
Desktop Notifications Fix for 30.0.1599.101

### DIFF
--- a/src/js/exchange.js
+++ b/src/js/exchange.js
@@ -138,7 +138,7 @@ function Exchange() {
                 return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]);
             }).join('&');
             exchange.lastNotify && exchange.lastNotify.close();
-            exchange.lastNotify = webkitNotifications.createNotification('http://www.rizwanashraf.com/wp-content/uploads/2013/07/outlook-web-app.png', data.title, data.message);
+            exchange.lastNotify = webkitNotifications.createNotification(chrome.extension.getURL('images/icon128.png'), data.title, data.message);
             exchange.lastNotify.onclick = onclick || Function.empty;
             exchange.lastNotify.show();
 


### PR DESCRIPTION
I have fixed the Desktop Notifications not working in Chrome 30.0.1599.101 and updated your goToInbox function to use the new chrome.tabs.query function that is replacing the depreciated getAllInWindow. Using the developer tools for extensions I verified this working in said version on OSX Mountain Lion.
