### PR TITLE
Fixing a bug with the exchange.work function to provide a fix where the ...

### DIFF
--- a/src/js/exchange.js
+++ b/src/js/exchange.js
@@ -284,6 +284,8 @@ function Exchange() {
         }
         else
         {
+            //if user does not set an internval on extension options b/c placeholder "looks" real; set to 5 minutes
+            if (exchange.options.updateInterval == "NaN") exchange.options.updateInterval = 300;
             timerId = setTimeout(exchange.work, exchange.options.updateInterval * 1000);
             exchange.xmlAction('folders', function () {
                 exchange.getUnread();


### PR DESCRIPTION
...code can enter the “else” statement if the user uses their keyboard to submit the “options” for the plugin (even if all options are not completed). This is possible without providing a typed value within the Update Interval field by keyboard only entry. Since an issue was filed with confusion around why “Save” is disabled this is likely to occur since an HTML5 “placeholder” value of “30” is provided that gives the illusion the field is already filled out.

Addresses possible bug as described in https://github.com/3axap4eHko/OWA-Notifier/issues/6#issuecomment-28034333
