### PR TITLE
Fixing automatic closing of notifications

### DIFF
--- a/src/js/exchange.js
+++ b/src/js/exchange.js
@@ -146,7 +146,9 @@ function Exchange() {
             exchange.notify  = window.webkitNotifications.createNotification(chrome.extension.getURL('images/icon128.png'), data.title, data.message);
             exchange.notify.onclick = onclick || Function.empty;
             exchange.notify.show();
-            setTimeout((function() { this.close();}).bind(exchange.notify), (exchange.options.displayTime || defaultConfig.displayTime) * 1000);
+            if (exchange.options.displayTime != 0) {
+              setTimeout((function() { exchange.notify && exchange.notify.cancel() }), exchange.options.displayTime * 1000);
+            }
         } else {
             window.webkitNotifications.requestPermission();
         }
@@ -173,7 +175,7 @@ function Exchange() {
                         },
                         function() {
                             exchange.goToInbox();
-                            this.close();
+                            exchange.notify.cancel();
                         }
                     );
 

--- a/src/owa_options.html
+++ b/src/owa_options.html
@@ -95,6 +95,7 @@
                         <span class="input-group-addon"> seconds</span>
                     </div>
                 </div>
+                <p>Set to 0 to display forever.</p>
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
This fixes issues #18 and #12. Setting the display time to 0 will now make the notification display until clicked.
