### PR TITLE
Fix of closing for the modal confirmation popup.

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -208,7 +208,7 @@
                                 account.idx = idx;
                             });
                             Extension.setAccounts(accounts).then(loadAccounts);
-                            $('#account-modal').modal('hide');
+                            $('#confirmation-modal').modal('hide');
                         });
                     }
                 },


### PR DESCRIPTION
When you delete an account the confirmation popup is displayed. When pressing "OK" record is removed, but the popup didn't disappear.